### PR TITLE
make it more exactly like bluebird's Promise.reduce

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ function reduce(fn, start) {
   assert.equal(typeof fn, 'function')
   return function(val) {
     val = Array.isArray(val) ? val : [val]
-    return val.reduce(function (promise, curr) {
+    return val.reduce(function (promise, curr, index, arr) {
       return promise.then(function (prev) {
-        return fn(prev, curr)
+        return fn(prev, curr, index, arr)
       })
     }, Promise.resolve(start))
   }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ function reduce(fn, start) {
 
     const length = val.length;
 
+    if (length === 0) {
+      return Promise.resolve(start);
+    }
+
     return val.reduce(function (promise, curr, index, arr) {
       return promise.then(function (prev) {
         if (prev === undefined && length === 1) {

--- a/index.js
+++ b/index.js
@@ -11,8 +11,15 @@ function reduce(fn, start) {
   assert.equal(typeof fn, 'function')
   return function(val) {
     val = Array.isArray(val) ? val : [val]
+
+    const length = val.length;
+
     return val.reduce(function (promise, curr, index, arr) {
       return promise.then(function (prev) {
+        if (prev === undefined && length === 1) {
+          return curr;
+        }
+
         return fn(prev, curr, index, arr)
       })
     }, Promise.resolve(start))

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ test('promise-reduce should assert input types', function (t) {
   t.throws(reduce.bind(null, 123))
 })
 
-test('promise-reuduce should accept a single val', function (t) {
+test('promise-reduce should accept a single val', function (t) {
   t.plan(1)
 
   const res = Promise.resolve(2)
@@ -35,6 +35,30 @@ test('promise-reduce should reduce a fn', function (t) {
 
   function checkFn(val) {
     t.equal(6, val)
+  }
+})
+
+test('should pass reducer arguments to callback', function(t) {
+  const arrTest = [1, 2]
+
+  const res = Promise.resolve(arrTest)
+    .then(reduce(reduceFn, 0))
+    .then(checkFn)
+
+  function reduceFn(prev, next, index, arr) {
+    t.equal(4, arguments.length)
+    t.equal(arrTest, arr)
+
+    return new Promise(function (resolve) {
+      setTimeout(function () {
+        resolve(prev + next)
+      }, 1)
+    })
+  }
+
+  function checkFn(val) {
+    t.equal(3, val)
+    t.end()
   }
 })
 

--- a/test.js
+++ b/test.js
@@ -84,16 +84,8 @@ test('should not continue until last iteration has been resolved', function (t) 
 test('should not call callback when initial value is undefined and iterable contains one item', function (t) {
   t.plan(1)
   const res = Promise.resolve([1])
-    .then(reduce(reduceFn, undefined))
+    .then(reduce(function() {}, undefined))
     .then(checkFn)
-
-  function reduceFn(prev, next) {
-    return new Promise(function (resolve) {
-      setTimeout(function () {
-        resolve(prev + next)
-      }, 1)
-    })
-  }
 
   function checkFn(val) {
     t.equal(1, val, 'should return the item in iterable')
@@ -103,16 +95,8 @@ test('should not call callback when initial value is undefined and iterable cont
 test('should not call callback when iterable is empty', function (t) {
   t.plan(1)
   const res = Promise.resolve([])
-    .then(reduce(reduceFn, 10))
+    .then(reduce(function() {}, 10))
     .then(checkFn)
-
-  function reduceFn(prev, next) {
-    return new Promise(function (resolve) {
-      setTimeout(function () {
-        resolve(prev + next)
-      }, 1)
-    })
-  }
 
   function checkFn(val) {
     t.equal(10, val, 'should return initial value')

--- a/test.js
+++ b/test.js
@@ -99,3 +99,22 @@ test('should not call callback when initial value is undefined and iterable cont
     t.equal(1, val, 'should return the item in iterable')
   }
 })
+
+test('should not call callback when iterable is empty', function (t) {
+  t.plan(1)
+  const res = Promise.resolve([])
+    .then(reduce(reduceFn, 10))
+    .then(checkFn)
+
+  function reduceFn(prev, next) {
+    return new Promise(function (resolve) {
+      setTimeout(function () {
+        resolve(prev + next)
+      }, 1)
+    })
+  }
+
+  function checkFn(val) {
+    t.equal(10, val, 'should return initial value')
+  }
+})

--- a/test.js
+++ b/test.js
@@ -80,3 +80,22 @@ test('should not continue until last iteration has been resolved', function (t) 
     t.equal(6, val)
   }
 })
+
+test('should not call callback when initial value is undefined and iterable contains one item', function (t) {
+  t.plan(1)
+  const res = Promise.resolve([1])
+    .then(reduce(reduceFn, undefined))
+    .then(checkFn)
+
+  function reduceFn(prev, next) {
+    return new Promise(function (resolve) {
+      setTimeout(function () {
+        resolve(prev + next)
+      }, 1)
+    })
+  }
+
+  function checkFn(val) {
+    t.equal(1, val, 'should return the item in iterable')
+  }
+})


### PR DESCRIPTION
implementation details described in [bluebird docs](http://bluebirdjs.com/docs/api/promise.reduce.html)

> If initialValue is undefined (or a promise that resolves to undefined) and the iterable contains only 1 item, the callback will not be called and the iterable's single item is returned. If the iterable is empty, the callback will not be called and initialValue is returned (which may be undefined).
